### PR TITLE
Added online install + some extra config

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,74 @@
+# Overview
+
+Elasticsearch is a flexible and powerful open source, distributed, real-time
+search and analytics engine. Architected from the ground up for use in
+distributed environments where reliability and scalability are must haves,
+Elasticsearch gives you the ability to move easily beyond simple full-text
+search. Through its robust set of APIs and query DSLs, plus clients for the
+most popular programming languages, Elasticsearch delivers on the near
+limitless promises of search technology.
+
+Excerpt from [elasticsearch.org](http://www.elasticsearch.org/overview/ "Elasticsearch Overview")
+
+# Usage
+
+There are two ways to deploy elasticsearch. There is a possibility to deploy
+this charm with the deb package being available on your local computer(offline)
+or by downloading the package from their repository(online). Those settings can
+be set in the `config.yaml`.
+
+```
+install-package:
+  type: string
+  default: "online"
+  description: |
+    This gives you the option to install elasticsearch 'offline' by giving the
+    path of the debian package or 'online' to install it by adding repository
+    and downloading the package.
+```
+
+### online
+
+You can simply deploy one node with:
+
+    juju deploy elasticsearch
+
+You can also deploy and relate the Kibana dashboard:
+
+    juju deploy kibana
+    juju add-relation kibana elasticsearch
+    juju expose kibana
+
+This will expose the Kibana web UI, which will then act as a front end to
+all subsequent Elasticsearch units.
+
+### offline
+
+Deploying the charm with the offline config can be done by giving the path to
+the packages
+
+`juju deploy elasticsearch --resource deb="/path/to/deb.package"`
+
+It is possible to deploy a beat and relate it to elasticsearch as well:
+```
+juju deploy my-service
+juju deploy metricbeat
+juju add-relation metricbeat:beats-host my-service
+juju add-relation metricbeat:elasticsearch elasticsearch:client
+```
+
+# Configuration
+
+- Not all the configuration options are implemented yet
+- This charm uses a java layer where you have the following config-options
+    - java-mayor
+    - java-flavor
+    - install-type
+The different config values are shown in the description of each option in the
+`config.yaml`
+
+# Contact Information
+
+## Elasticsearch
+
+- [Elasticsearch website](http://www.elasticsearch.org/)

--- a/config.yaml
+++ b/config.yaml
@@ -24,7 +24,7 @@ options:
     default: 9200
     description: |
       This is the port that where Elasticsearch will be running.
-  firewall_enabled:
+  firewall-enabled:
     type: boolean
     default: true
     description: |

--- a/config.yaml
+++ b/config.yaml
@@ -1,13 +1,45 @@
 options:
+  install_sources:
+    type: string
+    default: deb https://artifacts.elastic.co/packages/5.x/apt stable main
+    description: apt repository to fetch beats from
+  install_keys:
+    type: string
+    default: D88E42B4
+    description: repository key
+  install-package:
+    type: string
+    default: "online"
+    description: |
+      This gives you the option to install elasticsearch 'offline' by giving the
+      path of the debian package or 'online' to install it by adding repository
+      and downloading the package.
   cluster-name:
     type: string
     default: "elasticsearch"
     description: |
       This sets the elasticsearch cluster name.
-  firewall_enabled:
-    type: boolean
-    default: true
+  port:
+    type: int
+    default: 9200
     description: |
-      By default, the admin and peer ports (9200 and 9300) are only accessible
-      to clients and peers respectively. Switch this to false to enable access
-      from any machine.
+      This is the port that where Elasticsearch will be running.
+  java-major:
+    type: string
+    default: "8"
+    description: |
+      Major version of Java. Defaults to 8. Supported versions are 'Oracle java 8' and 'openjdk 6/7/8'
+  java-flavor:
+    type: string
+    default: "openjdk"
+    description: |
+      Flavor of Java to install. Possible options right now are 'openjdk'
+      and 'oracle'. Default value is 'openjdk'
+  install-type:
+    type: string
+    default: "full"
+    description: |
+      Type of install to perform. Valid options are 'jre' or 'full'. The
+      default is 'jre', which will install the Java Runtime Environment
+      (JRE). Setting this to 'full' will install the Java Development
+      Kit (JDK) in addition to the JRE.

--- a/config.yaml
+++ b/config.yaml
@@ -24,6 +24,13 @@ options:
     default: 9200
     description: |
       This is the port that where Elasticsearch will be running.
+  firewall_enabled:
+    type: boolean
+    default: true
+    description: |
+      By default, the admin and peer ports (9200 and 9300) are only accessible
+      to clients and peers respectively. Switch this to false to enable access
+      from any machine.
   java-major:
     type: string
     default: "8"

--- a/layer.yaml
+++ b/layer.yaml
@@ -1,10 +1,6 @@
 includes:
  - 'layer:basic'
  - 'layer:apt'
- # - 'interface:elasticsearch'
- # - 'interface:nrpe-external-master'
- # - 'interface:logs'
-options:
-  basic:
-    packages:
-      - default-jre
+ - 'layer:java'
+ - 'interface:elasticsearch'
+ - 'interface:nrpe-external-master'

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -19,7 +19,7 @@ subordinate: false
 #    interface: http
 provides:
   client:
-    interface: elasticsearchlocal
+    interface: elasticsearch
   nrpe-external-master:
     interface: nrpe-external-master
     scope: container

--- a/metadata.yaml
+++ b/metadata.yaml
@@ -14,20 +14,20 @@ tags:
  - search
  - logging
 subordinate: false
-peers:
-  peer:
-    interface: http
-# provides:
-  # client:
-  #   interface: elasticsearch
-  # nrpe-external-master:
-  #   interface: nrpe-external-master
-  #   scope: container
-  # logs:
-  #   interface: logs
-  # data:
-  #   interface: block-storage
-  #   scope: container
+#peers:
+#  peer:
+#    interface: http
+provides:
+  client:
+    interface: elasticsearchlocal
+  nrpe-external-master:
+    interface: nrpe-external-master
+    scope: container
+#  logs:
+#    interface: logs
+#  data:
+#    interface: block-storage
+#    scope: container
 resources:
   deb:
     type: file

--- a/reactive/elasticsearch.py
+++ b/reactive/elasticsearch.py
@@ -85,7 +85,7 @@ def reconfigure():
 
 @when('elasticsearch.configured', 'java.installed')
 def restart():
-    try:    
+    try:
         status_set('maintenance', 'Restarting elasticsearch')
         service_restart('elasticsearch')
         set_state('elasticsearch.ready')
@@ -100,17 +100,18 @@ def connect_to_client(client):
     cluster_name = conf['cluster-name']
     port = conf['port']
     client.configure(port, cluster_name)
-    host_ip = client.get_remote_ip()
-    print(host_ip)
-    add_fw_exception(host_ip)
+    clients = client.list_connected_clients_data()
+    for c in clients:
+        add_fw_exception(c)
 
 @when('client.broken')
 def remove_client(client):
-    host_ip = client.get_remote_ip()
-    print(host_ip)
-    subprocess.check_call(['ufw', 'delete', 'allow', 'proto', 'tcp', 'from',
-    host_ip, 'to', 'any', 'port', '9200'])
-
+    subprocess.check_output(['ufw', 'reset'], input='y\n', universal_newlines=True)
+    init_fw()
+    clients = client.list_connected_clients_data
+    for c in clients:
+        if c is not None:
+            add_fw_exception(c)
 
 ################################
 # Install and config functions #

--- a/reactive/elasticsearch.py
+++ b/reactive/elasticsearch.py
@@ -1,19 +1,21 @@
+#!/usr/bin/env python3
+# pylint: disable=c0111,c0103,c0301
 import os
+import subprocess
 
+from subprocess import CalledProcessError
 from apt.debfile import DebPackage
-
+from jujubigdata import utils
+from charms import apt
 from charms.reactive import (
+    hook,
     when,
     when_not,
     set_state,
     remove_state,
 )
-
-from charms import apt
-
+from charmhelpers.core import hookenv, templating
 from charmhelpers.core.host import service_restart
-from charmhelpers.core.templating import render
-
 from charmhelpers.core.hookenv import (
     log,
     config,
@@ -22,7 +24,70 @@ from charmhelpers.core.hookenv import (
 )
 
 
+@when('java.installed')
 @when_not('elasticsearch.installed')
+def preinstall():
+    conf = config()
+    install_package = conf['install-package']
+    if install_package == 'offline':
+        check_install_path()
+    else:
+        set_state('elasticsearch.apt-install')
+
+@when('elasticsearch.apt-install', 'java.installed')
+@when_not('apt.installed.elasticsearch')
+def apt_install():
+    status_set('maintenance', 'Queuing dependencies for install')
+    apt.queue_install(['elasticsearch'])
+
+@when('apt.installed.elasticsearch', 'java.installed')
+def level_set():
+    set_state('elasticsearch.installed')
+
+@when('elasticsearch.deb-install', 'java.installed')
+@when_not('elasticsearch.installed')
+def deb_install():
+    try:
+        deb = resource_get('deb')
+        d = DebPackage(deb)
+        d.install()
+        set_state('elasticsearch.installed')
+    except CalledProcessError:
+        status_set('error', 'Elasticsearch could not be installed with package')
+
+@when('elasticsearch.installed', 'java.installed')
+@when_not('elasticsearch.configured')
+def configure_elasticsearch():
+    status_set('maintenance', 'Configuring elasticsearch')
+    utils.re_edit_in_place('/etc/elasticsearch/elasticsearch.yml', {
+        r'#network.host: 192.168.0.1': 'network.host: ["_site_", "_local_"]',
+    })
+    set_state('elasticsearch.configured')
+
+@when('config-changed')
+def reconfigure():
+    status_set('maintenance', 'Configuring elasticsearch')
+    set_state('elasticsearch.configured')
+
+@when('elasticsearch.configured', 'java.installed')
+def restart():
+    try:
+        status_set('maintenance', 'Restarting elasticsearch')
+        service_restart('elasticsearch')
+        set_state('elasticsearch.ready')
+        status_set('active', 'Ready')
+    except CalledProcessError:
+        status_set('error', 'Could not restart elasticsearch')
+
+
+@when('client.connected')
+def connect_to_client(client):
+    conf = config()
+    cluster_name = conf['cluster-name']
+    port = conf['port']
+    client.configure(port, cluster_name)
+
+
 def check_install_path():
     # Make sure we've got the resource.
     try:
@@ -38,57 +103,7 @@ def check_install_path():
     if deb and filesize > 1000000:
         set_state('elasticsearch.deb-install')
         return
-    # We've got the resource, but it doesn't appear to have downloaded properly.
-    # Attempt apt installing elasticsearch instead.
-    set_state('elasticsearch.apt-install')
-
-
-@when('elasticsearch.apt-install')
-@when_not('apt.installed.elasticsearch')
-def apt_install():
-    status_set('maintenance', 'Queuing dependencies for install')
-    apt.queue_install(['elasticsearch'])
-
-
-@when('apt.installed.elasticsearch')
-def level_set():
-    set_state('elasticsearch.installed')
-
-
-@when('elasticsearch.deb-install')
-@when_not('elasticsearch.installed')
-def deb_install():
-    deb = resource_get('deb')
-    d = DebPackage(deb)
-    d.install()
-    set_state('elasticsearch.installed')
-
-
-@when('elasticsearch.installed')
-@when_not('elasticsearch.configured')
-def configure_elasticsearch():
-    status_set('maintenance', 'Configuring elasticsearch')
-    # render(
-    #     source = "elasticsearch.yml",
-    #     target = "/etc/elasticsearch/elasticsearch.yml",
-    #     owner = "root",
-    #     perms = 0o644,
-    #     context = {'config': hookenv.config()}
-    # )
-    set_state('elasticsearch.configured')
-    set_state('elasticsearch.restart')
-
-
-@when('config.changed')
-def reconfigure():
-    status_set('maintenance', 'Configuring elasticsearch')
-    remove_state('elasticsearch.configured')
-    set_state('elasticsearch.restart')
-
-
-@when('elasticsearch.restart')
-def restart():
-    status_set('maintenance', 'Restarting elasticsearch')
-    service_restart('elasticsearch')
-    remove_state('elasticsearch.restart')
-    status_set('active', 'Ready')
+    else:
+            # We've got the resource, but it doesn't appear to have downloaded properly.
+            # Attempt apt installing elasticsearch instead.
+        set_state('elasticsearch.apt-install')

--- a/templates/elasticsearch.yml
+++ b/templates/elasticsearch.yml
@@ -1,10 +1,7 @@
-cluster.name: {{ config.cluster_name }}
+cluster.name: {{ clustername }}
 http.port: 9200
 network.host: ["_site_", "_local_"]
 discovery.zen.ping.multicast.enabled: false
 discovery.zen.ping.unicast.hosts:
-{% for reln in relations.peer %}
-  - {{ reln['private-address'] }}
-{% endfor %}
-# workaround for Kibana4 Export Everything bug https://github.com/elastic/kibana/issues/5524
+
 index.max_result_window: 2147483647


### PR DESCRIPTION
## Overview
- there is now a possibility to deploy the charm with the package given as a resource or the charm can be deployed by adding the elasticsearch repo and downloading the latest version from the repo

### README.md
- added a README.md file with some information about elasticsearch and the types of deployment
-TODO: Explain the configuration options.

### Config.yaml + layer.yaml +metadata.yaml
- I used a local java layer which gives you to possibilities to install openjdk or oracle jdk. This used to install openjdk 8  because Elasticsearch needs it to run.
- The Elasticsearch interface is a local interface I used which now has a provides.py. (in my test I renamed the local interface to elasticsearchlocal and used that one in the yaml files)
- The relations I made are with a local metricbeat charm
- Port is given as an option in config but not completely implemented yet
- I removed the firewall_enabled option since I'm looking for a better solution instead of  completely shutting down the container/machines firewall
- added the elasticsearch repo for the ES 5 package 

### elasticsearch.py
- almost nothing changed for the deployment with the package. just rearranged some methods.
- atm not working with a template to render in the configuration. I'm using the jujubigdata utils to change the value of network.host to make it accesible for beats in the same model to get a relation with elasticsearch
- added a method which will give clustername and port when a 'client' relation is established 

## TODO
- thinking about more configuration options that are required and how to implement them in the best way
- elasticsearch.yml still needs a few options that need to be set. Not sure if templates would be better then jujubigdata utils in this situation.  